### PR TITLE
Refacotred update list. Added tests for watchlistService

### DIFF
--- a/controller/watchlistController.js
+++ b/controller/watchlistController.js
@@ -62,6 +62,9 @@ router.put("/:listId", authenticateToken, async (req, res) => {
         if (err.message === "Unauthorized: You can only update your own watchlist.") {
             return res.status(403).json({ error: err.message });
         }
+        if (err.message === "A watchlist with that name already exists!") {
+            return res.status(409).json({ error: err.message });
+        }
 
         // server error
         res.status(500).json({ error: "Internal Server Error" });

--- a/service/watchlistService.js
+++ b/service/watchlistService.js
@@ -94,6 +94,14 @@ async function updateWatchlist(userId, listId, data) {
             throw new Error("Unauthorized: You can only update your own watchlist.");
         }
 
+        const watchlistByName = await watchlistDao.getWatchlistByUserIdAndListName(userId, listName);
+
+        // Check if the name already exists
+        // If a list with that name is found, ckeck if it is the same as the one currently being updated
+        if (watchlistByName && watchlistByName[0].listId !== listId) {
+            throw new Error("A watchlist with that name already exists!");
+        }
+
         const updatedList = await watchlistDao.updateWatchlist(listId, {listName, isPublic});
 
         return {

--- a/test/watchlistService.test.js
+++ b/test/watchlistService.test.js
@@ -1,0 +1,69 @@
+const watchlistService = require("../service/watchlistService");
+const watchlistDao = require("../repository/watchlistDAO");
+const uuid = require('uuid');
+
+jest.mock("../repository/watchlistDAO");
+jest.mock('uuid');
+
+describe("updateWatchlist", () => {
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("should update the watchlist successfully", async () => {
+        const userId = "user123";
+        const listId = "list123";
+        const data = { listName: "Updated List", isPublic: true };
+
+        watchlistDao.getWatchlistByListId.mockResolvedValue({ userId }); //mock the userId in the existing list
+        watchlistDao.updateWatchlist.mockResolvedValue({ listId, ...data });
+
+        const result = await watchlistService.updateWatchlist(userId, listId, data);
+
+        expect(result).toEqual({
+            message: "Watchlist updated successfully",
+            watchlist: { listId, ...data },
+        });
+    });
+
+    it("should not throw an error if the watchlist with the same name is the one being updated", async () => {
+        const userId = "user123";
+        const listId = "list123";
+        const listName = "my list";
+        watchlistDao.getWatchlistByUserIdAndListName.mockResolvedValue([{ listId, listName }]);
+
+        watchlistDao.getWatchlistByListId.mockResolvedValue({ userId, listId, listName });
+        watchlistDao.updateWatchlist.mockResolvedValue({ listId, listName, isPublic: true });
+
+        const result = await watchlistService.updateWatchlist(userId, listId, { listName, isPublic: true });
+
+        expect(result).toHaveProperty("message", "Watchlist updated successfully");
+    });
+
+    test("should throw an error if list name is empty", async () => {
+        await expect(watchlistService.updateWatchlist("user123", "list123", { listName: " ", isPublic: true }))
+            .rejects.toThrow("List name cannot be empty.");
+    });
+
+    test("should throw an error if user is not authorized", async () => {
+        watchlistDao.getWatchlistByListId.mockResolvedValue({ userId: "anotherUser" });
+
+        await expect(watchlistService.updateWatchlist("user123", "list123", { listName: "Updated", isPublic: true }))
+            .rejects.toThrow("Unauthorized: You can only update your own watchlist.");
+    });
+
+    test("should throw an error if watchlist is not found", async () => {
+        watchlistDao.getWatchlistByListId.mockResolvedValue(null);
+
+        await expect(watchlistService.updateWatchlist("user123", "list123", { listName: "Updated", isPublic: true }))
+            .rejects.toThrow("WatchList not found");
+    });
+
+    test("should throw an error if the name already exists", async () => {
+        watchlistDao.getWatchlistByUserIdAndListName.mockResolvedValue([{listId: "list123", listName: "Updated"}])
+        watchlistDao.getWatchlistByListId.mockResolvedValue({listId: "list345", userId: "user123"})
+        await expect(watchlistService.updateWatchlist("user123", "list345", { listName: "Updated", isPublic: true }))
+            .rejects.toThrow("A watchlist with that name already exists!");
+    });
+});


### PR DESCRIPTION
Refactored update watchlist to check if listName already exists. Also user is allowed to update watchlist and keep the old name(only updating isPublic)